### PR TITLE
Added CI for playwright

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -2,12 +2,12 @@ name: Full Stack E2E Tests
 
 on:
   push:
-    branches: [ main, ci, develop ]
+    branches: [ main, ci, dev ]
     paths:
       - 'frontend/**'
       - 'backend/**'
   pull_request:
-    branches: [ main, ci, develop ]
+    branches: [ main, ci, dev ]
     paths:
       - 'frontend/**'
       - 'backend/**'

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,170 @@
+name: Full Stack E2E Tests
+
+on:
+  push:
+    branches: [ main, ci, develop ]
+    paths:
+      - 'frontend/**'
+      - 'backend/**'
+  pull_request:
+    branches: [ main, ci, develop ]
+    paths:
+      - 'frontend/**'
+      - 'backend/**'
+
+jobs:
+  e2e:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    
+    strategy:
+      matrix:
+        browser: [chromium, firefox, webkit]
+
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_PASSWORD: authpass123
+          POSTGRES_USER: authuser
+          POSTGRES_DB: authdb
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5400:5432
+
+      redis:
+        image: redis:7-alpine
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 6379:6379
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Cache Go modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Install backend dependencies
+        working-directory: ./backend
+        run: go mod download
+
+      - name: Install frontend dependencies
+        working-directory: ./frontend
+        run: npm ci
+
+      - name: Run TypeScript check
+        working-directory: ./frontend
+        run: npx tsc --noEmit
+
+      - name: Run linting
+        working-directory: ./frontend
+        run: npm run lint
+
+      - name: Install Playwright Browsers
+        working-directory: ./frontend
+        run: npx playwright install --with-deps
+
+      - name: Build frontend
+        working-directory: ./frontend
+        run: npm run build
+
+      - name: Start backend
+        working-directory: ./backend
+        run: |
+          go run main.go &
+          sleep 10
+        env:
+          DATABASE_URL: postgres://authuser:authpass123@localhost:5400/authdb?sslmode=disable
+          REDIS_HOST: localhost
+          REDIS_PORT: 6379
+          JWT_SECRET: test-secret-key
+          PORT: 4000
+
+      - name: Wait for backend to be ready
+        run: |
+          for i in {1..30}; do
+            if curl -f http://localhost:4000/status >/dev/null 2>&1; then
+              echo "Backend is ready!"
+              break
+            fi
+            echo "Waiting for backend... ($i/30)"
+            sleep 2
+          done
+
+      - name: Start frontend dev server
+        working-directory: ./frontend
+        run: |
+          npm run dev &
+          sleep 5
+        env:
+          VITE_BASE_URL: http://localhost:4000
+
+      - name: Wait for frontend to be ready
+        run: |
+          for i in {1..30}; do
+            if curl -f http://localhost:5173 >/dev/null 2>&1; then
+              echo "Frontend is ready!"
+              break
+            fi
+            echo "Waiting for frontend... ($i/30)"
+            sleep 2
+          done
+
+      - name: Run Playwright tests
+        working-directory: ./frontend
+        run: npx playwright test --project=${{ matrix.browser }}
+        env:
+          VITE_BASE_URL: http://localhost:4000
+          CI: true
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-${{ matrix.browser }}
+          path: frontend/playwright-report/
+          retention-days: 7
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-${{ matrix.browser }}
+          path: frontend/test-results/
+          retention-days: 7
+
+      - name: Upload screenshots on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: failure-screenshots-${{ matrix.browser }}
+          path: frontend/test-results/
+          retention-days: 7

--- a/frontend/e2e/login.spec.ts
+++ b/frontend/e2e/login.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from '@playwright/test';
+
+// These routes are called during app boot and login page render.
+// We stub them so the UI can load without a real backend in CI.
+test.describe('login route (mocked backend)', () => {
+  test('renders login UI elements', async ({ page, context }) => {
+    // Make sure locale and theme are deterministic
+    await context.addCookies([
+      { name: 'i18next', value: 'en', url: 'http://localhost:5173' },
+    ]);
+
+    // Mock KubeStellar status check to keep user on /login
+    await page.route('**/api/kubestellar/status', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ allReady: true }),
+      });
+    });
+
+    // Mock auth/me to appear logged out
+    await page.route('**/api/me', async route => {
+      await route.fulfill({ status: 401, contentType: 'application/json', body: '{}' });
+    });
+
+    // Mock login endpoint to succeed (not used in this test, but handy for future)
+    await page.route('**/api/login', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          accessToken: 'fake',
+          refreshToken: 'fake',
+          username: 'tester',
+        }),
+      });
+    });
+
+    await page.goto('/login', { waitUntil: 'domcontentloaded' });
+
+    // Heading text is translated; assert by text keys rendered
+    await expect(page.getByRole('heading', { name: /welcome back/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /sign in/i })).toBeVisible();
+    await expect(page.getByPlaceholder(/username/i)).toBeVisible();
+    await expect(page.getByPlaceholder(/password/i)).toBeVisible();
+  });
+});
+
+


### PR DESCRIPTION
### Description
This pull request adds a new GitHub Actions workflow to automate full stack end-to-end (E2E) testing using Playwright. The workflow sets up the required backend and frontend environments, runs tests across multiple browsers, and uploads test artifacts for further inspection.

Key additions in the workflow:

**E2E Testing Automation:**

* Introduced `.github/workflows/playwright.yml` to define a CI workflow that triggers on changes to the `frontend` or `backend` directories for specific branches and pull requests.
* Configured the workflow to run Playwright E2E tests across `chromium`, `firefox`, and `webkit` browsers using a matrix strategy.

**Environment Setup:**

* Added services for `postgres` and `redis` containers with health checks to support backend requirements.
* Included steps to install dependencies, build the frontend, and start both backend and frontend servers with appropriate environment variables.

**Test Reporting and Artifacts:**

* Implemented steps to upload Playwright reports, test results, and failure screenshots as workflow artifacts for each browser tested.


<!-- Clearly describe the purpose of this PR. Include any relevant details or context. -->



### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [ ] Updated ...
- [ ] Refactored ...
- [ ] Fixed ...
- [ ] Added tests for ...

### Checklist

Please ensure the following before submitting your PR:

- [ ] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have tested the changes locally and ensured they work as expected.
- [ ] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->

### Additional Notes

<!-- Add any other context, suggestions, or questions related to this PR. -->
